### PR TITLE
feat(genshare): map editorial_policy to feature flags

### DIFF
--- a/conf/genshare.json.default
+++ b/conf/genshare.json.default
@@ -3,6 +3,14 @@
   "versions": {
     "previous": {
       "version": "v81.2.1",
+      "editorialPolicyOptions": {
+        "AUTH": { "suggested_das_generation": true, "funding_statement": true },
+        "TFOD": { "suggested_das_generation": false, "funding_statement": true },
+        "PLOS": { "suggested_das_generation": false, "funding_statement": true },
+        "JID": { "suggested_das_generation": false, "funding_statement": true },
+        "SURR": { "suggested_das_generation": false, "funding_statement": true },
+        "default": { "suggested_das_generation": false, "funding_statement": false }
+      },
       "cache": {
         "enabled": true,
         "ttlAfterZeroConsumersMs": 172800000,
@@ -45,6 +53,14 @@
     },
     "latest": {
       "version": "v81.3.0",
+      "editorialPolicyOptions": {
+        "AUTH": { "suggested_das_generation": true, "funding_statement": true },
+        "TFOD": { "suggested_das_generation": false, "funding_statement": true },
+        "PLOS": { "suggested_das_generation": false, "funding_statement": true },
+        "JID": { "suggested_das_generation": false, "funding_statement": true },
+        "SURR": { "suggested_das_generation": false, "funding_statement": true },
+        "default": { "suggested_das_generation": false, "funding_statement": false }
+      },
       "processPDF": {
         "url": "http://localhost:5001/snapshot",
         "method": "POST",

--- a/src/utils/genshareManager.js
+++ b/src/utils/genshareManager.js
@@ -373,6 +373,31 @@ function filterOptions(options, user, session) {
   return filteredOptions;
 }
 
+/**
+ * Resolve the per-feature flags driven by the request's editorial_policy, using
+ * the active genshare version's `editorialPolicyOptions` mapping in
+ * conf/genshare.json. Falls back to the mapping's `default` entry, then to all
+ * features off. This is server-authoritative — clients cannot set these directly.
+ *
+ * @param {Object} versionConfig - the active genshare version config block
+ * @param {string} editorialPolicy - the resolved editorial_policy (e.g. "AUTH", "TFOD")
+ * @param {Object} session - session for logging
+ * @returns {{suggested_das_generation: boolean, funding_statement: boolean}}
+ */
+function resolveEditorialPolicyOptions(versionConfig, editorialPolicy, session) {
+  const mapping = (versionConfig && versionConfig.editorialPolicyOptions) || {};
+  const entry = mapping[editorialPolicy] || mapping.default || {};
+  const resolved = {
+    suggested_das_generation: entry.suggested_das_generation === true,
+    funding_statement: entry.funding_statement === true
+  };
+  session.addLog(
+    `[GenShare] editorial_policy="${editorialPolicy}" mapped to ` +
+      `suggested_das_generation=${resolved.suggested_das_generation}, funding_statement=${resolved.funding_statement}`
+  );
+  return resolved;
+}
+
 // ============================================================================
 // CSV DATA BUILDING FUNCTIONS
 // ============================================================================
@@ -1041,9 +1066,20 @@ const processPDF = async (data, session) => {
   const noCache = filteredOptions.no_cache === true;
   delete filteredOptions.no_cache;
 
+  // Resolve per-feature flags from the editorial_policy mapping (authoritative,
+  // so drop any client-supplied values before re-injecting the mapped ones).
+  delete filteredOptions.suggested_das_generation;
+  delete filteredOptions.funding_statement;
+  const editorialPolicyOptions = resolveEditorialPolicyOptions(
+    versionConfig,
+    filteredOptions.editorial_policy || '',
+    session
+  );
+
   // Add options with decision_tree_path for the request only
   const requestOptions = {
     ...filteredOptions,
+    ...editorialPolicyOptions,
     request_id: session.requestId,
     decision_tree_path: true,
     debug: true


### PR DESCRIPTION
Add a per-version `editorialPolicyOptions` mapping in conf/genshare.json that resolves each editorial_policy to the suggested_das_generation and funding_statement flags, forwarded to genshare-service in the request options. Server-authoritative: any client-supplied values are dropped. Falls back to a `default` entry, then all-false.