### PR TITLE
feat(users): support full user config editing and genshare.options

### DIFF
--- a/scripts/manage_users.js
+++ b/scripts/manage_users.js
@@ -56,27 +56,53 @@ function generateClientSecret() {
   return crypto.randomBytes(32).toString('hex');
 }
 
+/**
+ * Default per-user `genshare.options` block applied to new users.
+ *
+ * Each option is validated request-side by `genshareManager.filterOptions`:
+ * a requested value not in `available` is clamped back to `default`. These
+ * defaults are the conservative non-admin set — `editorial_policy` may be one
+ * of PLOS/TFOD/SURR (default TFOD), and `no_cache` is locked to false (the
+ * user cannot bypass the cache). Grant broader access (e.g. `no_cache`
+ * `available: [true, false]` for admins) via the `options` key of the
+ * genshareSettings argument or the `update-genshare` command.
+ * @returns {Object} a fresh copy of the default options block
+ */
+function getDefaultGenShareOptions() {
+  return {
+    editorial_policy: {
+      available: ['PLOS', 'TFOD', 'SURR'],
+      default: 'TFOD'
+    },
+    no_cache: {
+      available: [false],
+      default: false
+    }
+  };
+}
+
 function addUser(userId, rateLimit, genshareSettings = {}) {
   const users = loadUsers();
   if (users[userId]) {
     console.log(`User ${userId} already exists.`);
     return;
   }
-  
+
   // Use jwtManager to generate a permanent token
   const token = jwtManager.signPermanentToken(userId);
   const clientSecret = generateClientSecret();
-  
+
   users[userId] = {
     token,
     client_secret: clientSecret,
     rateLimit: rateLimit || { max: 100, windowMs: 15 * 60 * 1000 },
     genshare: {
-      authorizedVersions: genshareSettings.authorizedVersions || ['default'],
-      defaultVersion: genshareSettings.defaultVersion || 'default',
+      authorizedVersions: genshareSettings.authorizedVersions || ['latest'],
+      defaultVersion: genshareSettings.defaultVersion || 'latest',
+      returnedFields: genshareSettings.returnedFields || [],
       availableFields: genshareSettings.availableFields || [],
       restrictedFields: genshareSettings.restrictedFields || [],
-      returnedFields: genshareSettings.returnedFields || []
+      options: genshareSettings.options || getDefaultGenShareOptions()
     },
     reports: {
       authorizedVersions: [],
@@ -151,11 +177,12 @@ function updateUserGenShareSettings(userId, genshareSettings) {
   // Initialize genshare settings if they don't exist
   if (!users[userId].genshare) {
     users[userId].genshare = {
-      authorizedVersions: ['default'],
-      defaultVersion: 'default',
+      authorizedVersions: ['latest'],
+      defaultVersion: 'latest',
+      returnedFields: [],
       availableFields: [],
       restrictedFields: [],
-      returnedFields: []
+      options: getDefaultGenShareOptions()
     };
   }
   
@@ -182,6 +209,17 @@ function listUsers() {
       console.log(`    Restricted Fields: ${userData.genshare.restrictedFields.length ? userData.genshare.restrictedFields.join(', ') : 'none'}`);
       const returnedFields = userData.genshare.returnedFields || [];
       console.log(`    Returned Fields: ${returnedFields.length ? returnedFields.join(', ') : 'all (no response shaping)'}`);
+      const options = userData.genshare.options || {};
+      const optionKeys = Object.keys(options);
+      if (optionKeys.length) {
+        console.log(`    Options:`);
+        optionKeys.forEach(optionKey => {
+          const { available = [], default: defaultValue } = options[optionKey] || {};
+          console.log(`      ${optionKey}: available [${available.join(', ')}], default ${defaultValue}`);
+        });
+      } else {
+        console.log(`    Options: none`);
+      }
     }
     console.log('---');
   });
@@ -241,6 +279,7 @@ function main() {
       console.log('  node manage_users.js update-genshare user123 \'{"authorizedVersions": ["default", "v2"], "defaultVersion": "v2"}\'');
       console.log('  node manage_users.js update-genshare user123 \'{"availableFields": ["article_id", "das_presence", "data_url"]}\'');
       console.log('  node manage_users.js update-genshare user123 \'{"returnedFields": ["article_id", "das_presence"]}\'  # ordered whitelist: response shaping only, not access control');
+      console.log('  node manage_users.js update-genshare user123 \'{"options": {"editorial_policy": {"available": ["PLOS", "TFOD", "SURR"], "default": "TFOD"}, "no_cache": {"available": [true, false], "default": false}}}\'  # per-user option access (validated by filterOptions)');
       console.log('  node manage_users.js refresh-client-secret user123');
     }
   }

--- a/src/controllers/snapshotS3ManagerController.js
+++ b/src/controllers/snapshotS3ManagerController.js
@@ -2,7 +2,34 @@
 const fs = require('fs');
 const axios = require('axios');
 const config = require('../config');
-const { getAllUsers, getUserById, updateUser } = require('../utils/userManager');
+const { getAllUsers, getUserById, updateUser, replaceUser } = require('../utils/userManager');
+
+/**
+ * User fields that must never be exposed over the admin API nor overwritten via
+ * the full-document update endpoint. Reading these back would leak credentials;
+ * the JWT token in particular must stay in sync with JWT_SECRET, so it is
+ * managed only through the dedicated CLI refresh flows.
+ */
+const PROTECTED_USER_FIELDS = ['token', 'client_secret'];
+
+/**
+ * Build a client-safe copy of a user, omitting protected credential fields and
+ * keeping every other field (rateLimit, genshare, reports, role, googleSheets,
+ * and any future config keys) so the admin UI can display and edit them.
+ * @param {string} id - The user ID
+ * @param {Object} userData - The raw user object (may include protected fields)
+ * @returns {Object} - Safe user object with `id` and all non-protected fields
+ */
+const toSafeUser = (id, userData) => {
+  const safeUser = { id };
+  Object.keys(userData).forEach((key) => {
+    if (key === 'id' || PROTECTED_USER_FIELDS.includes(key)) {
+      return;
+    }
+    safeUser[key] = userData[key];
+  });
+  return safeUser;
+};
 
 /**
  * Get snapshot-reports base URL and API key from reports config
@@ -76,13 +103,9 @@ const getUsers = async (req, res) => {
   try {
     const users = getAllUsers();
 
-    // Remove sensitive data (tokens, client_secrets)
-    const safeUsers = Object.entries(users).map(([id, userData]) => ({
-      id,
-      rateLimit: userData.rateLimit,
-      genshare: userData.genshare,
-      reports: userData.reports
-    }));
+    // Expose every field except protected credentials so the admin UI can edit
+    // the full configuration (role, googleSheets, custom keys, ...).
+    const safeUsers = Object.entries(users).map(([id, userData]) => toSafeUser(id, userData));
 
     return res.json({
       success: true,
@@ -108,13 +131,8 @@ const getUser = async (req, res) => {
     const { userId } = req.params;
     const user = getUserById(userId);
 
-    // Remove sensitive data
-    const safeUser = {
-      id: user.id,
-      rateLimit: user.rateLimit,
-      genshare: user.genshare,
-      reports: user.reports
-    };
+    // Expose every field except protected credentials.
+    const safeUser = toSafeUser(userId, user);
 
     return res.json({
       success: true,
@@ -147,37 +165,32 @@ const updateUserComplete = async (req, res) => {
     const { userId } = req.params;
     const updates = req.body;
 
-    // Get current user to verify it exists
+    if (!updates || typeof updates !== 'object' || Array.isArray(updates)) {
+      return res.status(400).json({
+        success: false,
+        error: 'invalid_payload',
+        message: 'Request body must be a user configuration object'
+      });
+    }
+
+    // Get current user to verify it exists and to preserve protected fields
     const user = getUserById(userId);
 
-    // Build the update object with only allowed fields
-    const allowedUpdates = {};
+    // Full-document replace: the submitted object becomes the new user config,
+    // so removing a field in the editor removes it on disk. Protected
+    // credentials are never accepted from the client and `id` is the map key,
+    // not a stored property — strip them, then re-inject the stored secrets so
+    // they are preserved untouched.
+    const newUserData = { ...updates };
+    delete newUserData.id;
+    PROTECTED_USER_FIELDS.forEach((field) => {
+      delete newUserData[field];
+      if (user[field] !== undefined) {
+        newUserData[field] = user[field];
+      }
+    });
 
-    if (updates.rateLimit) {
-      allowedUpdates.rateLimit = {
-        ...user.rateLimit,
-        ...updates.rateLimit
-      };
-    }
-
-    if (updates.genshare) {
-      allowedUpdates.genshare = {
-        ...user.genshare,
-        ...updates.genshare
-      };
-    }
-
-    if (updates.reports) {
-      allowedUpdates.reports = {
-        ...user.reports,
-        ...updates.reports
-      };
-    }
-
-    // Update user with allowed fields only
-    if (Object.keys(allowedUpdates).length > 0) {
-      updateUser(userId, allowedUpdates);
-    }
+    replaceUser(userId, newUserData);
 
     // Get updated user data
     const updatedUser = getUserById(userId);
@@ -185,12 +198,7 @@ const updateUserComplete = async (req, res) => {
     return res.json({
       success: true,
       message: 'User updated successfully',
-      data: {
-        id: userId,
-        rateLimit: updatedUser.rateLimit,
-        genshare: updatedUser.genshare,
-        reports: updatedUser.reports
-      }
+      data: toSafeUser(userId, updatedUser)
     });
   } catch (error) {
     if (error.message.includes('not found')) {

--- a/src/utils/configWatcher.js
+++ b/src/utils/configWatcher.js
@@ -29,29 +29,42 @@ const watchConfig = (configPath, defaultValue = {}) => {
     return watched.get(resolved).proxy;
   }
 
-  // Initial load
   let data;
-  try {
-    data = JSON.parse(fs.readFileSync(resolved, 'utf8'));
-  } catch (error) {
-    logger.warn(`[ConfigWatcher] ${path.basename(resolved)} not found or invalid, using defaults`);
-    data = defaultValue;
-  }
 
-  // Set up file watcher with debounce
+  /**
+   * (Re)read the file into `data`. On failure, keeps the previous content (or
+   * the default on first load) so a bad write never wipes the in-memory config.
+   * @param {boolean} isInitial - True for the startup load (quieter logging)
+   * @returns {boolean} True if the file was read and parsed successfully
+   */
+  const reload = (isInitial = false) => {
+    try {
+      data = JSON.parse(fs.readFileSync(resolved, 'utf8'));
+      if (!isInitial) {
+        logger.info(`[ConfigWatcher] Reloaded ${path.basename(resolved)}`);
+      }
+      return true;
+    } catch (error) {
+      if (isInitial) {
+        logger.warn(`[ConfigWatcher] ${path.basename(resolved)} not found or invalid, using defaults`);
+        data = defaultValue;
+      } else {
+        logger.error(`[ConfigWatcher] Failed to reload ${path.basename(resolved)}: ${error.message}`);
+        // Keep previous data on error
+      }
+      return false;
+    }
+  };
+
+  // Initial load
+  reload(true);
+
+  // Set up file watcher with debounce (handles edits made outside this process)
   let debounceTimer = null;
   try {
     fs.watch(resolved, () => {
       if (debounceTimer) clearTimeout(debounceTimer);
-      debounceTimer = setTimeout(() => {
-        try {
-          data = JSON.parse(fs.readFileSync(resolved, 'utf8'));
-          logger.info(`[ConfigWatcher] Reloaded ${path.basename(resolved)}`);
-        } catch (err) {
-          logger.error(`[ConfigWatcher] Failed to reload ${path.basename(resolved)}: ${err.message}`);
-          // Keep previous data on error
-        }
-      }, DEBOUNCE_MS);
+      debounceTimer = setTimeout(() => reload(false), DEBOUNCE_MS);
     });
   } catch (watchError) {
     logger.warn(`[ConfigWatcher] Could not watch ${path.basename(resolved)}: ${watchError.message}`);
@@ -69,9 +82,28 @@ const watchConfig = (configPath, defaultValue = {}) => {
     }
   });
 
-  watched.set(resolved, { proxy });
+  watched.set(resolved, { proxy, reload });
 
   return proxy;
 };
 
-module.exports = { watchConfig };
+/**
+ * Force a synchronous re-read of a watched config file.
+ *
+ * fs.watch fires asynchronously (plus a debounce), so a process that writes a
+ * watched file and then reads it back through the proxy would observe stale
+ * data until the watcher catches up. Writers should call this immediately after
+ * writing so subsequent reads in the same process are consistent. No-op if the
+ * path is not currently being watched.
+ * @param {string} configPath - The path passed to watchConfig
+ * @returns {boolean} True if the file was reloaded successfully
+ */
+const reloadConfig = (configPath) => {
+  const entry = watched.get(path.resolve(configPath));
+  if (entry && typeof entry.reload === 'function') {
+    return entry.reload(false);
+  }
+  return false;
+};
+
+module.exports = { watchConfig, reloadConfig };

--- a/src/utils/userManager.js
+++ b/src/utils/userManager.js
@@ -1,7 +1,7 @@
 // File: src/utils/userManager.js
 const fs = require('fs');
 const config = require('../config');
-const { watchConfig } = require('./configWatcher');
+const { watchConfig, reloadConfig } = require('./configWatcher');
 
 // Watch users config (auto-reloads on file change)
 const usersConfig = watchConfig(config.usersPath);
@@ -42,7 +42,37 @@ const updateUser = (userId, userData) => {
 
   users[userId] = { ...users[userId], ...userData };
   fs.writeFileSync(config.usersPath, JSON.stringify(users, null, 2));
-  // The watcher will automatically pick up the change
+  // Refresh the in-memory copy synchronously so reads immediately after this
+  // write are consistent (fs.watch fires async + debounced). The watcher still
+  // catches external edits.
+  reloadConfig(config.usersPath);
+};
+
+/**
+ * Replace a user's full configuration.
+ *
+ * Unlike updateUser (a shallow merge), this overwrites the whole user object:
+ * top-level keys absent from userData are removed. Use this for full-document
+ * edits where the caller has already assembled the complete desired config
+ * (e.g. the admin "Edit JSON" flow). Callers are responsible for carrying over
+ * any protected fields (token, client_secret) they want preserved.
+ * @param {string} userId - The user ID to replace
+ * @param {Object} userData - The complete user object to store
+ */
+const replaceUser = (userId, userData) => {
+  // Read fresh from disk for write operations to avoid race conditions
+  const users = JSON.parse(fs.readFileSync(config.usersPath, 'utf8'));
+
+  if (!users[userId]) {
+    throw new Error(`User ${userId} not found`);
+  }
+
+  users[userId] = userData;
+  fs.writeFileSync(config.usersPath, JSON.stringify(users, null, 2));
+  // Refresh the in-memory copy synchronously so reads immediately after this
+  // write are consistent (fs.watch fires async + debounced). The watcher still
+  // catches external edits.
+  reloadConfig(config.usersPath);
 };
 
 /**
@@ -126,6 +156,7 @@ module.exports = {
   getAllUsers,
   getUserById,
   updateUser,
+  replaceUser,
   validateClientCredentials,
   getUserGenShareVersions,
   getUserDefaultGenShareVersion,


### PR DESCRIPTION
Let the snapshot-s3-manager admin UI edit the complete user config instead of only rateLimit/genshare/reports:

- getUsers/getUser now return every field except the protected credentials (token, client_secret) via a shared toSafeUser helper, so role, googleSheets and any future keys are visible to the admin UI.
- updateUserComplete (PUT /users/:userId) does a full-document replace, stripping token/client_secret/id from the payload and re-injecting the stored secrets so they are preserved and never editable over the API.
- Add userManager.replaceUser for whole-object overwrites (updateUser keeps its shallow-merge semantics for the genshare/reports PATCH routes).
- Add genshare.options (editorial_policy, no_cache) to the manage_users.js user creation script and refresh its stale 'default' version defaults to 'latest' to match the current schema.

Fix stale reads after a write: configWatcher reloaded its in-memory copy only asynchronously (fs.watch + debounce), so a read right after a write returned old data. Add configWatcher.reloadConfig for a synchronous re-read and call it from updateUser/replaceUser after writing.